### PR TITLE
adds bundle exec in case rails isn't installed globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,14 @@ Rename application.yml.local to application.yml in /config directory for local e
 ### Initialize the database
 
 ```shell
-rails db:setup db:seed
+bundle exec rails db:setup db:seed
 ```
 ### Create data for local environment
 
 This will setup data for your local development and testing, look the data [here](https://github.com/arbob/Coronago-backend/blob/3f19d53637a53f660738f2671c5fb4ab17529fef/lib/tasks/development_data_seed.rake#L1) to start using it.
 
 ```shell
-rails development_tasks:seed_dev_data
+bundle exec rails development_tasks:seed_dev_data
 ```
 
 ### Run dev dependencies


### PR DESCRIPTION
Ran into an issue on setup where I didn't have rails installed globally for the particular ruby version. adds `bundle exec`  to ensure things are 👌 